### PR TITLE
Add security readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -64,5 +64,6 @@ We’d love to hear from you! Whether you have questions, feedback, or want to g
 - **Email**: [mail@opencloud.eu](mailto:mail@opencloud.eu) – For any direct questions.
 - **Mastodon**: [OpenCloud on Mastodon](https://social.opencloud.eu/@OpenCloud) – Follow us for the latest updates and join the conversation.
 - **GitHub Discussions**: [Join the Discussion](https://github.com/orgs/opencloud-eu/discussions) – Ask questions, share ideas, and engage with the community.
+- **Security**: Check our [Security Policy](SECURITY.md)
 
 We’re excited to have you join us on this journey to build a secure, open, and community-driven cloud platform!

--- a/profile/SECURITY.md
+++ b/profile/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+At OpenCloud we take all security aspects in all components of the platform seriously. We appreciate your efforts to responsibly disclose your findings, and will do our very best to acknowledge your contributions.
+
+## Reporting a Vulnerability
+
+> [!IMPORTANT] 
+> ** Please do not report security vulnerabilities through public GitHub issues. **
+
+If you have discovered a security matter with OpenCloud, please follow _general repsonsible disclosure guidelines_ and report the problem via email to [security@opencloud.eu](mailto:security@opencloud.eu?subject=[Security]%20Issues%20Report).
+
+Your report should include:
+
+* Affected project component(s) and their specific versions
+* A good description of the vulnerability
+* Steps to reproduce the issue, incl. potentially required test data or other needed details
+
+## What will follow?
+
+You will receive an initial acknowledgement within 24 hours.
+
+A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, and coordinate the fix and publication.
+
+The fix will be applied to the affected components of the proejct, be tested, and distributed in the next security release. The vulnerability will be publicly announced after the release.
+
+Thank you for your help!
+

--- a/profile/SECURITY.md
+++ b/profile/SECURITY.md
@@ -17,9 +17,9 @@ Your report should include:
 
 ## What will follow?
 
-You will receive an initial acknowledgement within 24 hours.
+You will receive an initial acknowledgement as soon as possible.
 
-A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, and coordinate the fix and publication.
+After that, member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, and coordinate the fix and publication.
 
 The fix will be applied to the affected components of the project, tested, and distributed in the next security release. The vulnerability will be publicly announced after the release.
 

--- a/profile/SECURITY.md
+++ b/profile/SECURITY.md
@@ -7,7 +7,7 @@ At OpenCloud we take all security aspects in all components of the platform seri
 > [!IMPORTANT] 
 > ** Please do not report security vulnerabilities through public GitHub issues. **
 
-If you have discovered a security matter with OpenCloud, please follow _general repsonsible disclosure guidelines_ and report the problem via email to [security@opencloud.eu](mailto:security@opencloud.eu?subject=[Security]%20Issues%20Report).
+If you have discovered a security matter with OpenCloud, please follow _general responsible disclosure guidelines_ and report the problem via email to [security@opencloud.eu](mailto:security@opencloud.eu?subject=[Security]%20Issues%20Report).
 
 Your report should include:
 
@@ -21,7 +21,7 @@ You will receive an initial acknowledgement within 24 hours.
 
 A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, and coordinate the fix and publication.
 
-The fix will be applied to the affected components of the proejct, be tested, and distributed in the next security release. The vulnerability will be publicly announced after the release.
+The fix will be applied to the affected components of the project, tested, and distributed in the next security release. The vulnerability will be publicly announced after the release.
 
 Thank you for your help!
 


### PR DESCRIPTION
Security Readme added, to be referenced from all other repositories. Needs to be updated once we have a more robust process.