### PR TITLE
Update README.md to add link to Translation Platform

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -72,6 +72,12 @@ OpenCloud is an open-source project that gives you a secure and private way to s
 ## Roadmap
 - Get an idea about our priorities and long-term plans: [Roadmap](https://opencloud.eu/roadmap)
 
+## Ways to Collaborate
+
+There are tasks available for everyone, such as:
+- Translation: You can assist in translating the UI through [Transifex](https://explore.transifex.com/opencloud-eu/opencloud-eu/) platform
+- You can shape the documentation at [docs.opencloud.eu](https://docs.opencloud.eu/docs/user/intro) through the following repository: [docs](https://github.com/opencloud-eu/docs)
+
 
 ## Contact Us
 


### PR DESCRIPTION
This PR is from the following discussion "Missing: Link to Translation Platform in README #809"