### PR TITLE
Add App Downloads

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -84,7 +84,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
         <img src="https://img.icons8.com/ios-filled/50/000000/windows-logo.png" alt="Windows" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
-        <a href="https://apps.microsoft.com/detail/9pbx43hcmldq?mode=direct">
+        <a target="_blank" href="https://apps.microsoft.com/detail/9pbx43hcmldq?mode=direct">
           <img src="https://img.shields.io/badge/Download-Microsoft_Store-20434f?style=for-the-badge&logo=microsoft&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>
@@ -94,7 +94,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
         <img src="https://img.icons8.com/ios-filled/50/000000/mac-os.png" alt="macOS" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
-        <a href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
+        <a target="_blank" href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
           <img src="https://img.shields.io/badge/Download-pkg-20434f?style=for-the-badge&logo=apple&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>
@@ -104,7 +104,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
         <img src="https://img.icons8.com/ios-filled/50/000000/linux.png" alt="Linux" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
-        <a href="https://github.com/opencloud-eu/desktop/releases/download/v1.0.0/OpenCloud_Desktop-v1.0.0-linux-gcc-x86_64.AppImage">
+        <a target="_blank" href="https://github.com/opencloud-eu/desktop/releases/download/v1.0.0/OpenCloud_Desktop-v1.0.0-linux-gcc-x86_64.AppImage">
           <img src="https://img.shields.io/badge/Download-AppImage-20434f?style=for-the-badge&logo=linux&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>
@@ -129,7 +129,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
       <td align="left" style="background-color:#ffffff;">
 Coming soon
         <!-- <a href="#">
-          <img src="https://img.shields.io/badge/Download-Play_Store-20434f?style=for-the-badge&logo=google-play&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+          <img target="_blank" src="https://img.shields.io/badge/Download-Play_Store-20434f?style=for-the-badge&logo=google-play&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a> -->
 <br/>
       </td>
@@ -139,7 +139,7 @@ Coming soon
         <img src="https://img.icons8.com/ios-filled/50/000000/ios-logo.png" alt="iOS" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
-        <a href="https://apps.apple.com/de/app/id6743121005">
+        <a target="_blank" href="https://apps.apple.com/de/app/id6743121005">
           <img src="https://img.shields.io/badge/Download-App_Store-20434f?style=for-the-badge&logo=appstore&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>

--- a/profile/README.md
+++ b/profile/README.md
@@ -140,7 +140,7 @@ Coming soon
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://apps.apple.com/de/app/id6743121005">
-          <img src="https://img.shields.io/badge/Download-App_Store-20434f?style=for-the-badge&logo=appstore&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+          <img src="https://img.shields.io/badge/Download-App_Store-20434f?style=for-the-badge&logo=appstore&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>
     </tr>

--- a/profile/README.md
+++ b/profile/README.md
@@ -85,7 +85,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://apps.microsoft.com/detail/9pbx43hcmldq?mode=direct">
-          <img src="https://img.shields.io/badge/Download-Microsoft_Store-20434f?style=for-the-badge&logo=microsoft&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+          <img src="https://img.shields.io/badge/Download-Microsoft_Store-20434f?style=for-the-badge&logo=microsoft&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>
     </tr>
@@ -95,7 +95,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
-          <img src="https://img.shields.io/badge/Download-pkg-20434f?style=for-the-badge&logo=apple&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+          <img src="https://img.shields.io/badge/Download-pkg-20434f?style=for-the-badge&logo=apple&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>
     </tr>
@@ -105,7 +105,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://github.com/opencloud-eu/desktop/releases/download/v1.0.0/OpenCloud_Desktop-v1.0.0-linux-gcc-x86_64.AppImage">
-          <img src="https://img.shields.io/badge/Download-AppImage-20434f?style=for-the-badge&logo=linux&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+          <img src="https://img.shields.io/badge/Download-AppImage-20434f?style=for-the-badge&logo=linux&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>
     </tr>

--- a/profile/README.md
+++ b/profile/README.md
@@ -81,7 +81,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
   <tbody>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/windows-logo.png" alt="Windows" style="height:28px"/>
+        <img src="https://img.icons8.com/?size=100&id=108792&format=png&color=000000" alt="Windows" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a target="_blank" href="https://apps.microsoft.com/detail/9pbx43hcmldq?mode=direct">
@@ -91,7 +91,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
     </tr>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/mac-os.png" alt="macOS" style="height:28px"/>
+        <img src="https://img.icons8.com/?size=100&id=30659&format=png&color=000000" alt="macOS" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
@@ -101,7 +101,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
     </tr>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/linux.png" alt="Linux" style="height:28px"/>
+        <img src="https://img.icons8.com/?size=100&id=17842&format=png&color=000000" alt="Linux" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a target="_blank" href="https://github.com/opencloud-eu/desktop/releases/download/v1.0.0/OpenCloud_Desktop-v1.0.0-linux-gcc-x86_64.AppImage">
@@ -124,7 +124,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
   <tbody>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/android-os.png" alt="Android" style="height:28px"/>
+        <img src="https://img.icons8.com/?size=100&id=17836&format=png&color=000000" alt="Android" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
 Coming soon
@@ -136,7 +136,7 @@ Coming soon
     </tr>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/ios-logo.png" alt="iOS" style="height:28px"/>
+        <img src="https://img.icons8.com/?size=100&id=20822&format=png&color=000000" alt="iOS" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a target="_blank" href="https://apps.apple.com/de/app/id6743121005">
@@ -146,6 +146,7 @@ Coming soon
     </tr>
   </tbody>
 </table>
+
 
 
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -81,7 +81,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
   <tbody>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/windows-logo.png" alt="Windows"/>
+        <img src="https://img.icons8.com/ios-filled/50/000000/windows-logo.png" alt="Windows" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://apps.microsoft.com/detail/9pbx43hcmldq?mode=direct">
@@ -91,7 +91,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
     </tr>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/mac-os.png" alt="macOS"/>
+        <img src="https://img.icons8.com/ios-filled/50/000000/mac-os.png" alt="macOS" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
@@ -101,7 +101,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
     </tr>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/linux.png" alt="Linux"/>
+        <img src="https://img.icons8.com/ios-filled/50/000000/linux.png" alt="Linux" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://github.com/opencloud-eu/desktop/releases/download/v1.0.0/OpenCloud_Desktop-v1.0.0-linux-gcc-x86_64.AppImage">
@@ -124,7 +124,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
   <tbody>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/android-os.png" alt="Android"/>
+        <img src="https://img.icons8.com/ios-filled/50/000000/android-os.png" alt="Android" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
 Coming soon
@@ -136,7 +136,7 @@ Coming soon
     </tr>
     <tr>
       <td align="center" style="background-color:#ffffff;">
-        <img src="https://img.icons8.com/ios-filled/50/000000/ios-logo.png" alt="iOS"/>
+        <img src="https://img.icons8.com/ios-filled/50/000000/ios-logo.png" alt="iOS" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
         <a href="https://apps.apple.com/de/app/id6743121005">

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@
 <h3 align="center">
   <b><a href="https://docs.opencloud.eu/docs/admin/getting-started/container/docker-compose-local">Get Started</a></b>
   •
-  <a href="https://github.com/opencloud-eu/opencloud/releases/latest">Download</a>
+  <a href="https://github.com/opencloud-eu/.github/edit/main/profile/README.md#download-desktop-app">Download</a>
   •
   <a href="https://github.com/orgs/opencloud-eu/discussions">Discussions</a>
   •
@@ -68,6 +68,87 @@ OpenCloud is an open-source project that gives you a secure and private way to s
 - 🕒 File history to track changes and restore previous versions  
 - 📱 Multi-device sync with offline access across all your devices  
 - and many more ...
+
+### Download Desktop App
+
+<table>
+  <thead>
+    <tr>
+      <th>Platform</th>
+      <th>Download</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="center" style="background-color:#ffffff;">
+        <img src="https://img.icons8.com/ios-filled/50/000000/windows-logo.png" alt="Windows"/>
+      </td>
+      <td align="left" style="background-color:#ffffff;">
+        <a href="https://apps.microsoft.com/detail/9pbx43hcmldq?mode=direct">
+          <img src="https://img.shields.io/badge/Download-Microsoft_Store-20434f?style=for-the-badge&logo=microsoft&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+        </a><br/>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="background-color:#ffffff;">
+        <img src="https://img.icons8.com/ios-filled/50/000000/mac-os.png" alt="macOS"/>
+      </td>
+      <td align="left" style="background-color:#ffffff;">
+        <a href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
+          <img src="https://img.shields.io/badge/Download-pkg-20434f?style=for-the-badge&logo=apple&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+        </a><br/>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="background-color:#ffffff;">
+        <img src="https://img.icons8.com/ios-filled/50/000000/linux.png" alt="Linux"/>
+      </td>
+      <td align="left" style="background-color:#ffffff;">
+        <a href="https://github.com/opencloud-eu/desktop/releases/download/v1.0.0/OpenCloud_Desktop-v1.0.0-linux-gcc-x86_64.AppImage">
+          <img src="https://img.shields.io/badge/Download-AppImage-20434f?style=for-the-badge&logo=linux&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+        </a><br/>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Download Mobile App
+
+<table>
+  <thead>
+    <tr>
+      <th>Platform</th>
+      <th>Download</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="center" style="background-color:#ffffff;">
+        <img src="https://img.icons8.com/ios-filled/50/000000/android-os.png" alt="Android"/>
+      </td>
+      <td align="left" style="background-color:#ffffff;">
+Coming soon
+        <!-- <a href="#">
+          <img src="https://img.shields.io/badge/Download-Play_Store-20434f?style=for-the-badge&logo=google-play&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+        </a> -->
+<br/>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="background-color:#ffffff;">
+        <img src="https://img.icons8.com/ios-filled/50/000000/ios-logo.png" alt="iOS"/>
+      </td>
+      <td align="left" style="background-color:#ffffff;">
+        <a href="https://apps.apple.com/de/app/id6743121005">
+          <img src="https://img.shields.io/badge/Download-App_Store-20434f?style=for-the-badge&logo=appstore&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;"/>
+        </a><br/>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
+
 
 ## Roadmap
 - Get an idea about our priorities and long-term plans: [Roadmap](https://opencloud.eu/roadmap)

--- a/profile/README.md
+++ b/profile/README.md
@@ -94,7 +94,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
         <img src="https://img.icons8.com/?size=100&id=30659&format=png&color=000000" alt="macOS" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
-        <a href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
+        <a href="https://github.com/opencloud-eu/desktop/releases/download/v1.0.0/OpenCloud_Desktop-v1.0.0-macos-clang-arm64.pkg">
           <img src="https://img.shields.io/badge/Download-pkg-20434f?style=for-the-badge&logo=apple&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@
 <p align="center">Secure, Simple and Reliable</p>
 
 <h3 align="center">
-  <b><a href="https://docs.opencloud.eu/docs/admin/getting-started/container/docker-compose-local">Get Started</a></b>
+  <b><a target="_blank" href="https://docs.opencloud.eu/docs/admin/getting-started/container/docker-compose-local">Get Started</a></b>
   •
   <a href="https://github.com/opencloud-eu/.github/edit/main/profile/README.md#download-desktop-app">Download</a>
   •
@@ -94,7 +94,7 @@ OpenCloud is an open-source project that gives you a secure and private way to s
         <img src="https://img.icons8.com/ios-filled/50/000000/mac-os.png" alt="macOS" style="height:28px"/>
       </td>
       <td align="left" style="background-color:#ffffff;">
-        <a target="_blank" href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
+        <a href="https://github.com/opencloud/opencloud/releases/latest/download/OpenCloud-macOS.pkg">
           <img src="https://img.shields.io/badge/Download-pkg-20434f?style=for-the-badge&logo=apple&logoColor=ffffff&labelColor=20434f&color=20434f&label=Download" style="width:200px;height:28px;"/>
         </a><br/>
       </td>


### PR DESCRIPTION
Currently its not easy for users to find the app downloads
marketing is preparing a download page, we should also provide a overview on gh for better guidance
- Add App Downloads
- Sorry - used html table to style the platform icons - styling in md-tables is quite limited cc @AlexAndBear 
- Attention: I used a static link (pined version) to the download of the PKG and AppImage. These links will be depracted soonish and should be replaced via links that link to the latest version. afaikl there is no easy way to achieve this.